### PR TITLE
Calibrator suggestor

### DIFF
--- a/scripts/find_pulsar_in_obs.py
+++ b/scripts/find_pulsar_in_obs.py
@@ -37,7 +37,8 @@ from astropy import units as u
 #MWA scripts
 import sn_flux_est as sfe
 from mwa_pb import primary_beam
-from mwa_metadb_utils import mwa_alt_az_za, getmeta, get_common_obs_metadata, get_obs_array_phase
+from mwa_metadb_utils import mwa_alt_az_za, getmeta, get_common_obs_metadata,
+                             get_obs_array_phase, find_obsids_meta_pages
 
 import logging
 logger = logging.getLogger(__name__)
@@ -322,28 +323,6 @@ def format_ra_dec(ra_dec_list, ra_col=0, dec_col=1):
 
     return ra_dec_list
 
-
-def find_obsids_meta_pages(params={'mode':'VOLTAGE_START'}):
-    """
-    Loops over pages for each page for MWA metadata calls
-    """
-    obsid_list = []
-    temp =[]
-    page = 1
-    #need to ask for a page of results at a time
-    while len(temp) == 200 or page == 1:
-        params['page'] = page
-        logger.debug("Page: {0}   params: {1}".format(page, params))
-        temp = getmeta(service='find', params=params)
-        if temp is not None:
-            # if there are non obs in the field (which is rare) None is returned
-            for row in temp:
-                obsid_list.append(row[0])
-        else:
-            temp = []
-        page += 1
-
-    return obsid_list
 
 def singles_source_search(ra, dec):
     """

--- a/scripts/find_pulsar_in_obs.py
+++ b/scripts/find_pulsar_in_obs.py
@@ -37,7 +37,7 @@ from astropy import units as u
 #MWA scripts
 import sn_flux_est as sfe
 from mwa_pb import primary_beam
-from mwa_metadb_utils import mwa_alt_az_za, getmeta, get_common_obs_metadata,\
+from mwa_metadb_utils import mwa_alt_az_za, get_common_obs_metadata,\
                              get_obs_array_phase, find_obsids_meta_pages
 
 import logging

--- a/scripts/find_pulsar_in_obs.py
+++ b/scripts/find_pulsar_in_obs.py
@@ -37,7 +37,7 @@ from astropy import units as u
 #MWA scripts
 import sn_flux_est as sfe
 from mwa_pb import primary_beam
-from mwa_metadb_utils import mwa_alt_az_za, getmeta, get_common_obs_metadata,
+from mwa_metadb_utils import mwa_alt_az_za, getmeta, get_common_obs_metadata,\
                              get_obs_array_phase, find_obsids_meta_pages
 
 import logging

--- a/utils/mwa_metadb_utils.py
+++ b/utils/mwa_metadb_utils.py
@@ -5,6 +5,30 @@ import argparse
 logger = logging.getLogger(__name__)
 
 
+def find_obsids_meta_pages(params=None):
+    """
+    Loops over pages for each page for MWA metadata calls
+    """
+    if params is None:
+        params = {'mode':'VOLTAGE_START'}
+    obsid_list = []
+    temp =[]
+    page = 1
+    #need to ask for a page of results at a time
+    while len(temp) == 200 or page == 1:
+        params['page'] = page
+        logger.debug("Page: {0}   params: {1}".format(page, params))
+        temp = getmeta(service='find', params=params)
+        if temp is not None:
+            # if there are non obs in the field (which is rare) None is returned
+            for row in temp:
+                obsid_list.append(row[0])
+        else:
+            temp = []
+        page += 1
+
+    return obsid_list
+
 def get_obs_array_phase(obsid):
     """
     For the input obsid will work out the observations array phase in the form


### PR DESCRIPTION
Added an option to mwa_metadb_utils.py that will print the calibrations IDs for an observation within two days sorted by how far away they were in time

Here is an example output:
`>python mwa_metadb_utils.py -c 1221399680`
-------------------------    Obs Info    --------------------------
Obs Name:           SMART_B01
Creator:            stremblay
Array phase:        P2C
~FWHM (arcminute)   18.56
Start time:         1221399680
Stop time:          1221404480
Duration (s):       4800
RA Pointing (deg):  320.004656300209
DEC Pointing (deg): -55.090570788379
Channels:           [109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132]
Centrefreq (MHz):   154.24

Calibration ID|Hrs away|Cal Target
    1221405408|    1.59|3c444_121
    1221387272|    3.45|HerA_121
    1221428512|    8.01|PicA_121
    1221342176|   15.97|PicA_121
    1221473696|   20.56|HerA_121
    1221487384|   24.36|low_J2334-4_2018B_2458382
    1221487624|   24.43|low_3C444_2018B_2458382
    1221300848|   27.45|HerA_121
    1221505848|   29.49|PicA_121
    1221514840|   31.99|PicA_121
    1221255848|   39.95|PicA_121
    1221560120|   44.57|HerA_121