### PR TITLE
Multi pixel beamformer calibrate once

### DIFF
--- a/make_beam/form_beam.cu
+++ b/make_beam/form_beam.cu
@@ -33,8 +33,8 @@ extern "C" {
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
 {
     /* Wrapper function for GPU/CUDA error handling. Every CUDA call goes through
-       this function. It will return a message giving your the error string,
-       file name and line of the error. Aborts on error. */
+      this function. It will return a message giving your the error string,
+      file name and line of the error. Aborts on error. */
 
     if (code != 0)
     {
@@ -57,37 +57,97 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=t
 // maximum number of pointings (currently)
 #define NPOINTING 4
 
-
-
-__global__ void beamform_kernel( uint8_t *data,
-                                 ComplexDouble *W,
-                                 ComplexDouble *J,
-                                 double invw,
-                                 ComplexDouble *Bd,
-                                 float *C,
-                                 float *I,
-                                 int p,
-                                 int coh_pol)
+__global__ void invj_the_data( uint8_t       *data,
+                               ComplexDouble *J,
+                               ComplexDouble *W,
+                               ComplexDouble *JDx,
+                               ComplexDouble *JDy,
+                               float         *Ia,
+                               int            incoh )
 /* Layout for input arrays:
- *   data [nsamples] [nchan] [NPFB] [NREC] [NINC] -- see docs
- *   W    [NSTATION] [nchan] [NPOL]               -- weights array
- *   J    [NSTATION] [nchan] [NPOL] [NPOL]        -- jones matrix
- * Layout for output arrays:
- *   Bd   [nsamples] [nchan]   [NPOL]             -- detected beam
- *   C    [nsamples] [NSTOKES] [nchan]            -- coherent full stokes
- *   I    [nsamples] [nchan]                      -- incoherent
- *   p                                            -- pointing number
- *   coh_pol                                      -- coherent polorisation number
- */
+*   data [nsamples] [nchan] [NPFB] [NREC] [NINC] -- see docs
+*   J    [NSTATION] [nchan] [NPOL] [NPOL]        -- jones matrix
+*   incoh --true if outputing an incoherent beam
+* Layout for output arrays:
+*   JDx  [nsamples] [nchan] [NPFB] [NREC] [NINC]
+*   JDy  [nsamples] [nchan] [NPFB] [NREC] [NINC]
+*/
 {
     // Translate GPU block/thread numbers into meaning->l names
-    int s    = blockIdx.x;  /* The (s)ample number */
-    int ns   = gridDim.x;   /* The (n)umber of (s)amples (=10000)*/
-    int c    = blockIdx.y;  /* The (c)hannel number */
-    int nc   = gridDim.y;   /* The (n)umber of (c)hannels (=128) */
+    int c    = blockIdx.x;  /* The (c)hannel number */
+    int nc   = gridDim.x;   /* The (n)umber of (c)hannels (=128) */
+    int s    = blockIdx.y;  /* The (s)ample number */
+
+    int ant  = threadIdx.x; /* The (ant)enna number */
+
+    ComplexDouble Dx, Dy;
+    // Convert input data to complex float
+    Dx  = UCMPLX4_TO_CMPLX_FLT(data[D_IDX(s,c,ant,0,nc)]);
+    Dy  = UCMPLX4_TO_CMPLX_FLT(data[D_IDX(s,c,ant,1,nc)]);
+
+    // If tile is flagged in the calibration, flag it in the incoherent beam
+    if (incoh)
+    {
+        if (CReald(W[W_IDX(0,ant,c,0,nc)]) == 0.0 &&
+            CImagd(W[W_IDX(0,ant,c,0,nc)]) == 0.0 &&
+            CReald(W[W_IDX(0,ant,c,1,nc)]) == 0.0 &&
+            CImagd(W[W_IDX(0,ant,c,1,nc)]) == 0.0)
+            Ia[JD_IDX(s,c,ant,nc)] = 0.0;
+        else
+            Ia[JD_IDX(s,c,ant,nc)] = DETECT(Dx) + DETECT(Dy);
+    }
+
+    // Calculate the first step (J*D) of the coherent beam (B = J*W*D)
+    //JDx = Jxx*Dx + Jxy*Dy
+    //JDy = Jyx*Dx + Jyy*Dy
+    //TODO The Jyx/Jxy terms ay be the wrong way around, double check this
+    JDx[JD_IDX(s,c,ant,nc)] = CAddd( CMuld( J[J_IDX(ant,c,0,0,nc)], Dx ),
+                                    CMuld( J[J_IDX(ant,c,1,0,nc)], Dy ) );
+    JDy[JD_IDX(s,c,ant,nc)] = CAddd( CMuld( J[J_IDX(ant,c,0,1,nc)], Dx ),
+                                    CMuld( J[J_IDX(ant,c,1,1,nc)], Dy ) );
+
+
+}
+
+__global__ void beamform_kernel( ComplexDouble *JDx,
+                                 ComplexDouble *JDy,
+                                 ComplexDouble *W,
+                                 float *Iin,
+                                 double invw,
+                                 int p,
+                                 int coh_pol,
+                                 int incoh,
+                                 int soffset,
+                                 int nchunk,
+                                 ComplexDouble *Bd,
+                                 float *C,
+                                 float *I )
+/* Layout for input arrays:
+*   JDx  [nsamples] [nchan] [NPFB] [NREC] [NINC] -- calibrated voltages
+*   JDy  [nsamples] [nchan] [NPFB] [NREC] [NINC]
+*   W    [NSTATION] [nchan] [NPOL]               -- weights array
+*   Iin  [nsamples] [nchan] [nant]               -- detected incoh
+*   invw                                         -- inverse atrix
+* Layout of input options
+*   p                                            -- pointing number
+*   coh_pol                                      -- coherent polorisation number
+*   incoh                                        -- true if outputing an incoherent beam
+*   soffset                                      -- sample offset (10000/nchunk)
+*   nchunk                                       -- number of chunks each second is split into
+* Layout for output arrays:
+*   Bd   [nsamples] [nchan]   [NPOL]             -- detected beam
+*   C    [nsamples] [NSTOKES] [nchan]            -- coherent full stokes
+*   I    [nsamples] [nchan]                      -- incoherent
+*/
+{
+    // Translate GPU block/thread numbers into meaning->l names
+    int c    = blockIdx.x;  /* The (c)hannel number */
+    int nc   = gridDim.x;   /* The (n)umber of (c)hannels (=128) */
+    int s    = blockIdx.y;  /* The (s)ample number */
+    int ns   = gridDim.y*nchunk;   /* The (n)umber of (s)amples (=10000)*/
     
     int ant  = threadIdx.x; /* The (ant)enna number */
-    int nant = blockDim.x;  /* The (n_umber of (ant)ennas */
+    int nant = blockDim.x;  /* The (n)_umber of (ant)ennas */
 
     /*// GPU profiling
     clock_t start, stop;
@@ -97,32 +157,24 @@ __global__ void beamform_kernel( uint8_t *data,
     // Calculate the beam and the noise floor
     __shared__ double Ia[NSTATION];
     __shared__ ComplexDouble Bx[NSTATION], By[NSTATION];
-    ComplexDouble Dx, Dy;
-    ComplexDouble WDx, WDy;
 
     __shared__ ComplexDouble Nxx[NSTATION], Nxy[NSTATION],
-                             Nyy[NSTATION];//Nyx[NSTATION]
+                            Nyy[NSTATION];//Nyx[NSTATION]
 
 
     /* Fix from Maceij regarding NaNs in output when running on Athena, 13 April 2018.
-       Apparently the different compilers and architectures are treating what were 
-       unintialised variables very differently */
+    Apparently the different compilers and architectures are treating what were 
+    unintialised variables very differently */
     
     Bx[ant]  = CMaked( 0.0, 0.0 );
     By[ant]  = CMaked( 0.0, 0.0 );
-
-    Dx  = CMaked( 0.0, 0.0 );
-    Dy  = CMaked( 0.0, 0.0 );
-
-    WDx = CMaked( 0.0, 0.0 );
-    WDy = CMaked( 0.0, 0.0 );
 
     Nxx[ant] = CMaked( 0.0, 0.0 );
     Nxy[ant] = CMaked( 0.0, 0.0 );
     //Nyx[ant] = CMaked( 0.0, 0.0 );
     Nyy[ant] = CMaked( 0.0, 0.0 );
 
-    if ( p == 0 ) Ia[ant] = 0.0;
+    if ((p == 0) && (incoh)) Ia[ant] = Iin[JD_IDX(s,c,ant,nc)];
 
     /*if ((p == 0) && (ant == 0) && (c == 0) && (s == 0))
     {
@@ -133,27 +185,8 @@ __global__ void beamform_kernel( uint8_t *data,
     
     // Calculate beamform products for each antenna, and then add them together
     // Calculate the coherent beam (B = J*W*D)
-    Dx  = UCMPLX4_TO_CMPLX_FLT(data[D_IDX(s,c,ant,0,nc)]);
-    Dy  = UCMPLX4_TO_CMPLX_FLT(data[D_IDX(s,c,ant,1,nc)]);
-
-
-    if ( p == 0 )
-    {
-        if (CReald(W[W_IDX(p,ant,c,0,nc)]) == 0.0 &&
-            CImagd(W[W_IDX(p,ant,c,0,nc)]) == 0.0 &&
-            CReald(W[W_IDX(p,ant,c,1,nc)]) == 0.0 &&
-            CImagd(W[W_IDX(p,ant,c,1,nc)]) == 0.0)
-            Ia[ant] = 0.0;
-        else
-            Ia[ant] = DETECT(Dx) + DETECT(Dy);
-    }
-    WDx = CMuld( W[W_IDX(p,ant,c,0,nc)], Dx );
-    WDy = CMuld( W[W_IDX(p,ant,c,1,nc)], Dy );
-
-    Bx[ant] = CAddd( CMuld( J[J_IDX(p,ant,c,0,0,nc)], WDx ),
-                               CMuld( J[J_IDX(p,ant,c,1,0,nc)], WDy ) );
-    By[ant] = CAddd( CMuld( J[J_IDX(p,ant,c,0,1,nc)], WDx ),
-                               CMuld( J[J_IDX(p,ant,c,1,1,nc)], WDy ) );
+    Bx[ant] = CMuld( W[W_IDX(p,ant,c,0,nc)], JDx[JD_IDX(s,c,ant,nc)] );
+    By[ant] = CMuld( W[W_IDX(p,ant,c,1,nc)], JDy[JD_IDX(s,c,ant,nc)] );
 
     Nxx[ant] = CMuld( Bx[ant], CConjd(Bx[ant]) );
     Nxy[ant] = CMuld( Bx[ant], CConjd(By[ant]) );
@@ -176,7 +209,7 @@ __global__ void beamform_kernel( uint8_t *data,
     {
         if (ant < h_ant)
         {
-            if (p == 0) Ia[ant] += Ia[ant+h_ant];
+            if ( (p == 0) && (incoh)) Ia[ant] += Ia[ant+h_ant];
             Bx[ant]  = CAddd( Bx[ant],  Bx[ant  + h_ant] );
             By[ant]  = CAddd( By[ant],  By[ant  + h_ant] );
             Nxx[ant] = CAddd( Nxx[ant], Nxx[ant + h_ant] );
@@ -203,25 +236,24 @@ __global__ void beamform_kernel( uint8_t *data,
     {
         float bnXX = DETECT(Bx[0]) - CReald(Nxx[0]);
         float bnYY = DETECT(By[0]) - CReald(Nyy[0]);
-        ComplexDouble bnXY = CSubd(
-                                 CMuld( Bx[0], CConjd( By[0] ) ),
-                                 Nxy[0] );
+        ComplexDouble bnXY = CSubd( CMuld( Bx[0], CConjd( By[0] ) ),
+                                    Nxy[0] );
 
         // The incoherent beam
-        I[I_IDX(s,c,nc)] = Ia[0];
+        if ( (p == 0) && (incoh)) I[I_IDX(s+soffset,c,nc)] = Ia[0];
 
         // Stokes I, Q, U, V:
-        C[C_IDX(p,s,0,c,ns,coh_pol,nc)] = invw*(bnXX + bnYY);
+        C[C_IDX(p,s+soffset,0,c,ns,coh_pol,nc)] = invw*(bnXX + bnYY);
         if ( coh_pol == 4 )
         {
-            C[C_IDX(p,s,1,c,ns,coh_pol,nc)] = invw*(bnXX - bnYY);
-            C[C_IDX(p,s,2,c,ns,coh_pol,nc)] =  2.0*invw*CReald( bnXY );
-            C[C_IDX(p,s,3,c,ns,coh_pol,nc)] = -2.0*invw*CImagd( bnXY );
+            C[C_IDX(p,s+soffset,1,c,ns,coh_pol,nc)] = invw*(bnXX - bnYY);
+            C[C_IDX(p,s+soffset,2,c,ns,coh_pol,nc)] =  2.0*invw*CReald( bnXY );
+            C[C_IDX(p,s+soffset,3,c,ns,coh_pol,nc)] = -2.0*invw*CImagd( bnXY );
         }
 
         // The beamformed products
-        Bd[B_IDX(p,s,c,0,ns,nc)] = Bx[0];
-        Bd[B_IDX(p,s,c,1,ns,nc)] = By[0];
+        Bd[B_IDX(p,s+soffset,c,0,ns,nc)] = Bx[0];
+        Bd[B_IDX(p,s+soffset,c,1,ns,nc)] = By[0];
     }
     /*if ((p == 0) && (ant == 0) && (c == 0) && (s == 0))
     {
@@ -232,8 +264,8 @@ __global__ void beamform_kernel( uint8_t *data,
     
 }
 
-__global__ void flatten_bandpass_I_kernel(float *I,
-                                     int nstep)/* uint8_t *Iout ) */
+__global__ void flatten_bandpass_I_kernel( float *I,
+                                           int nstep )
 {
     // For just doing stokes I
     // One block
@@ -273,7 +305,7 @@ __global__ void flatten_bandpass_I_kernel(float *I,
 }
 
 
-__global__ void flatten_bandpass_C_kernel(float *C, int nstep )
+__global__ void flatten_bandpass_C_kernel( float *C, int nstep )
 {
     // For just doing stokes I
     // One block
@@ -318,43 +350,44 @@ __global__ void flatten_bandpass_C_kernel(float *C, int nstep )
 }
 
 
+
 void cu_form_beam( uint8_t *data, struct make_beam_opts *opts,
                    ComplexDouble ****complex_weights_array,
-                   ComplexDouble *****invJi, int file_no, 
+                   ComplexDouble ****invJi, int file_no,
                    int npointing, int nstation, int nchan,
                    int npol, int outpol_coh, double invw,
                    struct gpu_formbeam_arrays *g,
                    ComplexDouble ****detected_beam, float *coh, float *incoh,
-                   cudaStream_t *streams )
+                   cudaStream_t *streams, int incoh_check, int nchunk )
 /* The CPU version of the beamforming operations, using OpenMP for
- * parallelisation.
- *
- * Inputs:
- *   data    = array of 4bit+4bit complex numbers. For data order, refer to the
- *             documentation.
- *   opts    = passed option parameters, containing meta information about the
- *             obs and the data
- *   W       = complex weights array. [npointing][nstation][nchan][npol]
- *   J       = inverse Jones matrix. [npointing][nstation][nchan][npol][npol]
- *   file_no = number of file we are processing, starting at 0.
- *   nstation     = 128
- *   nchan        = 128
- *   npol         = 2 (X,Y)
- *   outpol_coh   = 4 (I,Q,U,V)
- *   invw         = the reciprocal of the sum of the antenna weights
- *   g            = struct containing pointers to various arrays on
- *                  both host and device
- *
- * Outputs:
- *   detected_beam = result of beamforming operation, summed over antennas
- *                   [2*nsamples][nchan][npol]
- *   coh           = result in Stokes parameters (minus noise floor)
- *                   [nsamples][nstokes][nchan]
- *   incoh         = result (just Stokes I)
- *                   [nsamples][nchan]
- *
- * Assumes "coh" and "incoh" contain only zeros.
- */
+* parallelisation.
+*
+* Inputs:
+*   data    = array of 4bit+4bit complex numbers. For data order, refer to the
+*             documentation.
+*   opts    = passed option parameters, containing meta information about the
+*             obs and the data
+*   W       = complex weights array. [npointing][nstation][nchan][npol]
+*   J       = inverse Jones matrix.  [nstation][nchan][npol][npol]
+*   file_no = number of file we are processing, starting at 0.
+*   nstation     = 128
+*   nchan        = 128
+*   npol         = 2 (X,Y)
+*   outpol_coh   = 4 (I,Q,U,V)
+*   invw         = the reciprocal of the sum of the antenna weights
+*   g            = struct containing pointers to various arrays on
+*                  both host and device
+*
+* Outputs:
+*   detected_beam = result of beamforming operation, summed over antennas
+*                   [2*nsamples][nchan][npol]
+*   coh           = result in Stokes parameters (minus noise floor)
+*                   [nsamples][nstokes][nchan]
+*   incoh         = result (just Stokes I)
+*                   [nsamples][nchan]
+*
+* Assumes "coh" and "incoh" contain only zeros.
+*/
 {
     // Setup input values (= populate W and J)
     int p, ant, ch, pol, pol2;
@@ -372,46 +405,65 @@ void cu_form_beam( uint8_t *data, struct make_beam_opts *opts,
 
         for (pol2 = 0; pol2 < npol; pol2++)
         {
-            Ji = Wi*npol + pol2;
-            g->J[Ji] = invJi[p][ant][ch][pol][pol2];
+            Ji = ant * (npol*npol*nchan) +
+                 ch  * (npol*npol) +
+                 pol * (npol) +
+                 pol2;
+            g->J[Ji] = invJi[ant][ch][pol][pol2];
         }
     }
     // Copy the data to the device
     gpuErrchk(cudaMemcpyAsync( g->d_W,    g->W, g->W_size,    cudaMemcpyHostToDevice ));
     gpuErrchk(cudaMemcpyAsync( g->d_J,    g->J, g->J_size,    cudaMemcpyHostToDevice ));
-    gpuErrchk(cudaMemcpyAsync( g->d_data, data, g->data_size, cudaMemcpyHostToDevice ));
 
-    // Call the kernels
-    // sammples_chan(index=blockIdx.x  size=gridDim.x,
-    //               index=blockIdx.y  size=gridDim.y)
-    // stat_point   (index=threadIdx.x size=blockDim.x,
-    //               index=threadIdx.y size=blockDim.y)
-    dim3 samples_chan(opts->sample_rate, nchan);
-    dim3 stat(NSTATION);
-    // Send off a parrellel cuda stream for each pointing
-    for ( int p = 0; p < npointing; p++ )
-    {    
-        beamform_kernel<<<samples_chan, stat, 0, streams[p]>>>( g->d_data,
-                            g->d_W, g->d_J, invw, 
-                            g->d_Bd, g->d_coh, g->d_incoh, p, outpol_coh );
-            
-        gpuErrchk( cudaPeekAtLastError() );
+    // Divide the gpu calculation into multiple time chunks so there is enough room on the GPU
+    for (int ichunk = 0; ichunk < nchunk; ichunk++)
+    {
+        int dataoffset = ichunk * g->data_size / sizeof(uint8_t);
+        gpuErrchk(cudaMemcpyAsync( g->d_data,
+                                data + ichunk * g->data_size / sizeof(uint8_t),
+                                g->data_size, cudaMemcpyHostToDevice ));
 
-        // Flatten the bandpass 
-        if ( p == 0 )
+        // Call the kernels
+        // samples_chan(index=blockIdx.x  size=gridDim.x,
+        //              index=blockIdx.y  size=gridDim.y)
+        // stat_point  (index=threadIdx.x size=blockDim.x,
+        //              index=threadIdx.y size=blockDim.y)
+        //dim3 samples_chan(opts->sample_rate, nchan);
+        dim3 chan_samples( nchan, opts->sample_rate / nchunk );
+        dim3 stat( NSTATION );
+
+        // convert the data and multiply it by J
+        invj_the_data<<<chan_samples, stat>>>( g->d_data, g->d_J, g->d_W, g->d_JDx, g->d_JDy,
+                                            g->d_Ia, incoh_check );
+
+        // Send off a parrellel cuda stream for each pointing
+        for ( int p = 0; p < npointing; p++ )
         {
-            flatten_bandpass_I_kernel<<<1, nchan, 0, streams[p]>>>(g->d_incoh,
-                                                     opts->sample_rate);
+            beamform_kernel<<<chan_samples, stat, 0, streams[p]>>>( g->d_JDx, g->d_JDy,
+                            g->d_W, g->d_Ia, invw,
+                            p, outpol_coh , incoh_check, ichunk*opts->sample_rate/nchunk, nchunk,
+                            g->d_Bd, g->d_coh, g->d_incoh );
+
+            gpuErrchk( cudaPeekAtLastError() );
+
+            // Flatten the bandpass
+            if ( p == 0 )
+            {
+                flatten_bandpass_I_kernel<<<1, nchan, 0, streams[p]>>>( g->d_incoh,
+                                                                        opts->sample_rate );
+                gpuErrchk( cudaPeekAtLastError() );
+            }
+            // Now do the same for the coherent beam
+            dim3 chan_stokes(nchan, outpol_coh);
+            flatten_bandpass_C_kernel<<<npointing, chan_stokes, 0, streams[p]>>>( g->d_coh,
+                                                                        opts->sample_rate );
             gpuErrchk( cudaPeekAtLastError() );
         }
-        // Now do the same for the coherent beam
-        dim3 chan_stokes(nchan, outpol_coh);
-        flatten_bandpass_C_kernel<<<npointing, chan_stokes, 0, streams[p]>>>(g->d_coh, 
-                                                               opts->sample_rate);
-        gpuErrchk( cudaPeekAtLastError() );
+        gpuErrchk( cudaDeviceSynchronize() );
     }
     gpuErrchk( cudaDeviceSynchronize() );
-    
+
     // Copy the results back into host memory
     gpuErrchk(cudaMemcpyAsync( g->Bd, g->d_Bd,    g->Bd_size,    cudaMemcpyDeviceToHost ));
     gpuErrchk(cudaMemcpyAsync( incoh, g->d_incoh, g->incoh_size, cudaMemcpyDeviceToHost ));
@@ -438,16 +490,17 @@ void cu_form_beam( uint8_t *data, struct make_beam_opts *opts,
 }
 
 void malloc_formbeam( struct gpu_formbeam_arrays *g, unsigned int sample_rate,
-                      int nstation, int nchan, int npol, int outpol_coh, 
+                      int nstation, int nchan, int npol, int nchunk, int outpol_coh,
                       int outpol_incoh, int npointing, double time )
 {
     // Calculate array sizes for host and device
     g->coh_size   = npointing * sample_rate * outpol_coh * nchan * sizeof(float);
     g->incoh_size = sample_rate * outpol_incoh * nchan * sizeof(float);
-    g->data_size  = sample_rate * nstation * nchan * npol * sizeof(uint8_t);
+    g->data_size  = sample_rate * nstation * nchan * npol / nchunk * sizeof(uint8_t);
     g->Bd_size    = npointing * sample_rate * nchan * npol * sizeof(ComplexDouble);
     g->W_size     = npointing * nstation * nchan * npol * sizeof(ComplexDouble);
-    g->J_size     = npointing * nstation * nchan * npol * npol * sizeof(ComplexDouble);
+    g->J_size     = nstation * nchan * npol * npol * sizeof(ComplexDouble);
+    g->JD_size    = sample_rate * nstation * nchan / nchunk * sizeof(ComplexDouble);
 
     // Allocate host memory
     //g->W  = (ComplexDouble *)malloc( g->W_size );
@@ -460,18 +513,30 @@ void malloc_formbeam( struct gpu_formbeam_arrays *g, unsigned int sample_rate,
     cudaMallocHost( &g->Bd, g->Bd_size );
     cudaCheckErrors("cudaMallocHost Bd fail");
 
+    fprintf( stderr, "[%f] coh_size   %d  MB GPU mem\n", time, g->coh_size  /1000000 );
+    fprintf( stderr, "[%f] incoh_size %d  MB GPU mem\n", time, g->incoh_size/1000000 );
+    fprintf( stderr, "[%f] data_size  %d  MB GPU mem\n", time, g->data_size /1000000 );
+    fprintf( stderr, "[%f] Bd_size    %d  MB GPU mem\n", time, g->Bd_size   /1000000 );
+    fprintf( stderr, "[%f] W_size     %d  MB GPU mem\n", time, g->W_size    /1000000 );
+    fprintf( stderr, "[%f] J_size     %d  MB GPU mem\n", time, g->J_size    /1000000 );
+    fprintf( stderr, "[%f] JD_size    %d  MB GPU mem\n", time, g->JD_size*3 /1000000 );
+
+    int GPU_mem = (g->W_size + g->J_size + g->Bd_size + g->data_size +
+                    g->coh_size + g->incoh_size + 3*g->JD_size) /1000000000;
+
+    fprintf( stderr, "[%f]  %d GB GPU memory allocated\n", time, GPU_mem );
+
     // Allocate device memory
     gpuErrchk(cudaMalloc( (void **)&g->d_W,     g->W_size ));
     gpuErrchk(cudaMalloc( (void **)&g->d_J,     g->J_size ));
+    gpuErrchk(cudaMalloc( (void **)&g->d_JDx,   g->JD_size ));
+    gpuErrchk(cudaMalloc( (void **)&g->d_JDy,   g->JD_size ));
+    gpuErrchk(cudaMalloc( (void **)&g->d_Ia,    g->JD_size ));
     gpuErrchk(cudaMalloc( (void **)&g->d_Bd,    g->Bd_size ));
     gpuErrchk(cudaMalloc( (void **)&g->d_data,  g->data_size ));
     gpuErrchk(cudaMalloc( (void **)&g->d_coh,   g->coh_size ));
     gpuErrchk(cudaMalloc( (void **)&g->d_incoh, g->incoh_size ));
 
-    fprintf( stderr, "[%f]  %d GB GPU memory allocated\n", time, (g->W_size + g->J_size + 
-                                            g->Bd_size + g->data_size +
-                                            g->coh_size + g->incoh_size)
-                                            /1000000000 );
 }
 
 void free_formbeam( struct gpu_formbeam_arrays *g )

--- a/make_beam/form_beam.cu
+++ b/make_beam/form_beam.cu
@@ -98,12 +98,14 @@ __global__ void invj_the_data( uint8_t       *data,
     }
 
     // Calculate the first step (J*D) of the coherent beam (B = J*W*D)
-    //JDx = Jxx*Dx + Jxy*Dy
-    //JDy = Jyx*Dx + Jyy*Dy
-    //TODO The Jyx/Jxy terms ay be the wrong way around, double check this
+    // Nick: by my math the order should be:
+    // JDx = Jxx*Dx + Jxy*Dy
+    // JDy = Jyx*Dx + Jyy*Dy
+    // But switching yx and xy is the way it was done previously and appears
+    // to give higher signal to noise
     JDx[JD_IDX(s,c,ant,nc)] = CAddd( CMuld( J[J_IDX(0,ant,c,0,0,nc)], Dx ),
-                                     CMuld( J[J_IDX(0,ant,c,0,1,nc)], Dy ) );
-    JDy[JD_IDX(s,c,ant,nc)] = CAddd( CMuld( J[J_IDX(0,ant,c,1,0,nc)], Dx ),
+                                     CMuld( J[J_IDX(0,ant,c,1,0,nc)], Dy ) );
+    JDy[JD_IDX(s,c,ant,nc)] = CAddd( CMuld( J[J_IDX(0,ant,c,0,1,nc)], Dx ),
                                      CMuld( J[J_IDX(0,ant,c,1,1,nc)], Dy ) );
 
 

--- a/make_beam/form_beam.h
+++ b/make_beam/form_beam.h
@@ -30,17 +30,21 @@ struct gpu_formbeam_arrays
     size_t Bd_size;
     size_t W_size;
     size_t J_size;
+    size_t JD_size;
     ComplexDouble *W, *d_W;
     ComplexDouble *J, *d_J;
     ComplexDouble *Bd, *d_Bd;
+    ComplexDouble *JDx, *d_JDx;
+    ComplexDouble *JDy, *d_JDy;
     uint8_t *d_data;
     float   *d_coh;
     float   *d_incoh;
+    float   *d_Ia;
 };
 
 
 void malloc_formbeam( struct gpu_formbeam_arrays *g, unsigned int sample_rate,
-                      int nstation, int nchan, int npol, int outpol_coh,
+                      int nstation, int nchan, int npol, int nchunk, int outpol_coh,
                       int outpol_incoh, int npointing, double time );
 void free_formbeam( struct gpu_formbeam_arrays *g );
 
@@ -57,11 +61,15 @@ void free_formbeam( struct gpu_formbeam_arrays *g );
                                (c) * (NPOL)            + \
                                (pol))
 
-#define J_IDX(p,a,c,p1,p2,nc) ((p) *  (NPOL*NPOL*(nc)*NANT) + \
-                               (a)  * (NPOL*NPOL*(nc))      + \
-                               (c)  * (NPOL*NPOL)           + \
-                               (p1) * (NPOL)                + \
-                               (p2))
+#define J_IDX(p,a,c,p1,p2,nc)   ((p)  * (NPOL*NPOL*(nc)*NANT) + \
+                                 (a)  * (NPOL*NPOL*(nc))      + \
+                                 (c)  * (NPOL*NPOL)           + \
+                                 (p1) * (NPOL)                + \
+                                 (p2))
+
+#define JD_IDX(s,c,a,nc)      ((s) * (NANT*(nc)) + \
+                               (c) * (NANT)      + \
+                               (a))
 
 #define B_IDX(p,s,c,pol,ns,nc) ((p)  * (NPOL*(nc)*(ns))   + \
                                 (s)  * (NPOL*(nc))        + \
@@ -111,7 +119,7 @@ void cu_form_beam( uint8_t *data, struct make_beam_opts *opts, ComplexDouble ***
                    int npointing, int nstation, int nchan,
                    int npol, int outpol_coh, double invw, struct gpu_formbeam_arrays *g,
                    ComplexDouble ****detected_beam, float *coh, float *incoh,
-                   cudaStream_t *streams );
+                   cudaStream_t *streams, int incoh_check, int nchunk  );
 
 float *create_pinned_data_buffer_psrfits( size_t size );
         

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -176,8 +176,8 @@ void get_delays(
         struct delays          delay_vals[],
         struct metafits_info  *mi,
         ComplexDouble       ****complex_weights_array,  // output: cmplx[npointing][ant][ch][pol]
-        ComplexDouble      *****invJi                   // output: invJi[npointing][ant][ch][pol][pol]
-        ) {
+        ComplexDouble      *****invJi )                 // output: invJi[npointing][ant][ch][pol][pol]
+{
     
     int row;     // For counting through nstation*npol rows in the metafits file
     int ant;     // Antenna number

--- a/make_beam/make_beam.c
+++ b/make_beam/make_beam.c
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
         cu_form_beam( data, &opts, complex_weights_array, invJi, file_no,
                     npointing, nstation, nchan, npol, outpol_coh, invw, &gf,
                     detected_beam, data_buffer_coh, data_buffer_incoh,
-                    streams );
+                    streams, opts.out_incoh, nchunk );
 
         // Invert the PFB, if requested
         if (opts.out_vdif)

--- a/make_beam/make_beam.h
+++ b/make_beam/make_beam.h
@@ -25,7 +25,7 @@ void             destroy_complex_weights( ComplexDouble ****array, int npointing
                                           int nstation, int nchan );
 
 ComplexDouble *****create_invJi( int npointing, int nstation, int nchan, int pol );
-void              destroy_invJi( ComplexDouble *****array, int npointing, 
+void              destroy_invJi( ComplexDouble *****array, int npointing,
                                  int nstation, int nchan, int npol );
 
 ComplexDouble ****create_detected_beam( int npointing, int nsamples, int nchan, int npol );


### PR DESCRIPTION
Only calibrate the raw voltages once as they're direction independent (used to do it once per pointing)

It makes beamforming GPU calcs~63% faster after the first pointing