### PR TITLE
Hot fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you used polarimetry, please give credit by citing:
 [Xue et al. (2019)](https://ui.adsabs.harvard.edu/abs/2019PASA...36...25X/abstract)
 
 If you used the inverse PFB, please give credit by citing:
-[McSweeney et al. (2019)](https://ui.adsabs.harvard.edu/abs/2020arXiv200703171M/abstract)
+[McSweeney et al. (2020)](http://dx.doi.org/10.1017/pasa.2020.24)
 
 Status
 ------

--- a/scripts/calibrate_vcs.py
+++ b/scripts/calibrate_vcs.py
@@ -665,13 +665,14 @@ class RTScal(object):
         else:
             mem = 10240
         jobid = submit_slurm(rts_batch, commands,
-                                slurm_kwargs=slurm_kwargs,
-                                module_list=module_list,
-                                batch_dir=self.batch_dir,
-                                submit=self.submit,
-                                queue='gpuq',
-                                export="NONE",
-                                mem=mem)
+                             slurm_kwargs=slurm_kwargs,
+                             module_list=module_list,
+                             batch_dir=self.batch_dir,
+                             submit=self.submit,
+                             queue='gpuq',
+                             export="NONE",
+                             mem=mem,
+                             load_vcstools=False)
         jobids.append(jobid)
 
         return jobids
@@ -855,13 +856,14 @@ class RTScal(object):
             commands = list(self.script_body)  # make a copy of body to then extend
             commands.append("srun --export=all -N {0} -n {0} rts_gpu {1}".format(nnodes, k))
             jobid = submit_slurm(rts_batch, commands,
-                                    slurm_kwargs=slurm_kwargs,
-                                    module_list=module_list,
-                                    batch_dir=self.batch_dir,
-                                    submit=self.submit,
-                                    queue='gpuq',
-                                    export="NONE",
-                                    mem=mem)
+                                 slurm_kwargs=slurm_kwargs,
+                                 module_list=module_list,
+                                 batch_dir=self.batch_dir,
+                                 submit=self.submit,
+                                 queue='gpuq',
+                                 export="NONE",
+                                 mem=mem,
+                                 load_vcstools=False)
             jobids.append(jobid)
 
         return jobids

--- a/scripts/calibrate_vcs.py
+++ b/scripts/calibrate_vcs.py
@@ -656,8 +656,7 @@ class RTScal(object):
                         "ntasks-per-node": "1"}
         module_list = ["RTS/master"]
         commands = list(self.script_body)  # make a copy of body to then extend
-        #commands.append("module use /pawsey/mwa/software/python3/modulefiles")
-        #commands.append("module load RTS/master")
+        commands.append("export UCX_MEMTYPE_CACHE=n")
         commands.append("srun --export=all -N {0} -n {0} rts_gpu {1}".format(nnodes, fname))
         hostname = socket.gethostname()
         if hostname.startswith("galaxy"):
@@ -854,6 +853,7 @@ class RTScal(object):
                             "ntasks-per-node": "1"}
             module_list= ["RTS/master"]
             commands = list(self.script_body)  # make a copy of body to then extend
+            commands.append("export UCX_MEMTYPE_CACHE=n")
             commands.append("srun --export=all -N {0} -n {0} rts_gpu {1}".format(nnodes, k))
             jobid = submit_slurm(rts_batch, commands,
                                  slurm_kwargs=slurm_kwargs,

--- a/scripts/process_vcs.py
+++ b/scripts/process_vcs.py
@@ -8,7 +8,6 @@ import tempfile
 import atexit
 import datetime
 from time import sleep, strptime, strftime
-import distutils.spawn
 import sqlite3 as lite
 from astropy.io import fits as pyfits
 from astropy.time import Time
@@ -123,7 +122,6 @@ def ensure_metafits(data_dir, obs_id, metafits_file):
         logger.warning("At the moment, even through the downloaded file is "
                        "labelled as a ppd file this is not true.")
         logger.warning("This is hopefully a temporary measure.")
-        #obsdownload = distutils.spawn.find_executable("obsdownload.py")
 
         get_metafits = "wget http://ws.mwatelescope.org/metadata/fits?obs_id={0} -O {1}".format(obs_id, metafits_file)
         try:
@@ -210,7 +208,6 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
                  nice=0):
 
     logger.info("Downloading files from archive")
-    # voltdownload = distutils.spawn.find_executable("voltdownload.py") #Doesn't seem to be working on zeus for some reason
     voltdownload = "voltdownload.py"
     obsinfo = meta.getmeta(service='obs', params={'obs_id':str(obsid)})
     data_format = obsinfo['dataquality']
@@ -255,7 +252,7 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
         if data_type == 16:
             check_secs_to_run = "10:15:00"
 
-        checks = distutils.spawn.find_executable("checks.py")
+        checks = "checks.py"
         # Write out the checks batch file but don't submit it
         commands = []
         if vcs_database_id is not None:
@@ -278,7 +275,7 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
         # if we have tarballs we send the untar jobs to the workq
         if data_type == 16:
             commands.append("else")
-            untar = distutils.spawn.find_executable('untar.sh')
+            untar = 'untar.sh'
             untar_command = "-w {0} -o {1} -b {2} -e {3} -j {4} {5}".format(dl_dir,
                                 obsid, time_to_get, time_to_get+increment-1, n_untar,
                                 keep)
@@ -358,7 +355,7 @@ def download_cal(obs_id, cal_obs_id, data_dir, product_dir, vcs_database_id,
     # Downloads the visablities to  /astro/mwavcs/vcs/[cal_obs_id]/vis
     # but creates a link to it here /astro/mwavcs/vcs/[obs_id]/cal/[cal_obs_id]
     csvfile = os.path.join(batch_dir, "{0}_dl.csv".format(cal_obs_id))
-    obsdownload = distutils.spawn.find_executable("obsdownload.py")
+    obsdownload = "obsdownload.py"
     create_link(data_dir, 'vis', product_dir, 'vis')
     obsdownload_batch = "caldownload_{0}".format(cal_obs_id)
     secs_to_run = "03:00:00" # sometimes the staging can take a while...
@@ -403,9 +400,9 @@ def vcs_recombine(obsid, start_time, stop_time, increment, data_dir, product_dir
     mdir(data_dir + '/' + target_dir, 'Combined')
     create_link(data_dir, target_dir, product_dir, link)
     batch_dir = product_dir+"/batch/"
-    recombine = distutils.spawn.find_executable("recombine.py")
-    checks = distutils.spawn.find_executable("checks.py")
-    recombine_binary = distutils.spawn.find_executable("recombine")
+    recombine = "recombine.py"
+    checks = "checks.py"
+    recombine_binary = "recombine"
     for time_to_get in range(start_time,stop_time,increment):
         process_nsecs = increment if (time_to_get + increment <= stop_time) \
                                   else (stop_time - time_to_get + 1)

--- a/scripts/process_vcs.py
+++ b/scripts/process_vcs.py
@@ -298,7 +298,9 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
                                     "nice": nice},
                         vcstools_version=vcstools_version, submit=False,
                         outfile=batch_dir+check_batch+"_0.out",
-                        queue="zcpuq", export="NONE", mem=10240)
+                        queue="zcpuq", export="NONE", mem=10240,
+                        # Manually handing it the module dir as it should only run
+                        module_dir='/group/mwa/software/modulefiles')
 
         # Write out the tar batch file if in mode 15
         #if format == 16:
@@ -339,7 +341,9 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
                                     "nice" : nice},
                         vcstools_version=vcstools_version,
                         outfile=batch_dir+voltdownload_batch+"_1.out",
-                        queue="copyq", export="NONE", mem=5120)
+                        queue="copyq", export="NONE", mem=5120,
+                        # Manually handing it the module dir as it should only run
+                        module_dir='/group/mwa/software/modulefiles')
 
 
 def download_cal(obs_id, cal_obs_id, data_dir, product_dir, vcs_database_id,
@@ -383,7 +387,9 @@ def download_cal(obs_id, cal_obs_id, data_dir, product_dir, vcs_database_id,
                     module_list=module_list,
                     slurm_kwargs={"time": secs_to_run, "nice": nice},
                     vcstools_version=vcstools_version, queue="copyq",
-                    export="NONE", mem=4096)
+                    export="NONE", mem=4096,
+                    # Manually handing it the module dir as it should only run
+                    module_dir='/group/mwa/software/modulefiles')
 
 
 def vcs_recombine(obsid, start_time, stop_time, increment, data_dir, product_dir,

--- a/utils/job_submit.py
+++ b/utils/job_submit.py
@@ -25,7 +25,6 @@ export OMP_NUM_THREADS={threads}
 
 {switches}
 module use {module_dir}
-module load vcstools/{version}
 {modules}
 
 {script}
@@ -39,7 +38,7 @@ def submit_slurm(name, commands, tmpl=SLURM_TMPL, slurm_kwargs=None,
                  submit=True, outfile=None, queue="cpuq", export="NONE",
                  gpu_res=None, mem=1024, cpu_threads=1, temp_mem=None,
                  nice=0, shebag='#!/bin/bash -l',
-                 module_dir=None):
+                 module_dir=None, load_vcstools=True):
     """
     Making this function to cleanly submit SLURM jobs using a simple template.
 
@@ -210,7 +209,10 @@ def submit_slurm(name, commands, tmpl=SLURM_TMPL, slurm_kwargs=None,
     header = "\n".join(header)
 
     # construct the module loads
-    modules = []
+    if load_vcstools:
+        modules = ["module load vcstools/{0}\n".format(vcstools_version)]
+    else:
+        modules = []
     switches = []
     for m in module_list:
         if m == "vcstools":
@@ -243,7 +245,6 @@ def submit_slurm(name, commands, tmpl=SLURM_TMPL, slurm_kwargs=None,
     # format the template script
     tmpl = tmpl.format(shebag=shebag, script=commands, outfile=outfile, header=header,
                        switches=switches, modules=modules,
-                       version=vcstools_version,
                        cluster=cluster, partition=partition,
                        export=export, account=comp_config['group_account'][queue],
                        module_dir=module_dir,


### PR DESCRIPTION
- Manually hand Zeus copyq jobs the module directory so they still work on garrawarla
- Added export UCX_MEMTYPE_CACHE=n to RTS jobs so they work on Garrawarla
