### PR TITLE
Avoids duplicate calls to Hyperbeam's calc_jones() function

### DIFF
--- a/make_beam/beam_common.c
+++ b/make_beam/beam_common.c
@@ -162,10 +162,8 @@ void get_metafits_info( char *metafits, struct metafits_info *mi, unsigned int c
 
         // The amps should all be '1', except when the corresponding delay = '32'
         for (int j = 0; j < NDELAYS; j++){
-            fprintf(stderr, "%d ", mi->delays[i][j]);
             mi->amps[i][j] = (mi->delays[i][j] == 32 ? 0.0 : 1.0);
         }
-        fprintf(stderr, "\n");
     }
     // Invert value (flag off = full weight; flag on = zero weight)
     for (i = 0; i < mi->ninput; i++) {

--- a/make_beam/beam_common.h
+++ b/make_beam/beam_common.h
@@ -138,6 +138,7 @@ void parallactic_angle_correction(
     double az,    // azimuth angle (radians)
     double za);   // zenith angle (radians)
 
+int hash_dipole_config( double * );
 
 void get_metafits_info( char *metafits, struct metafits_info *mi, unsigned int chan_width );
 void destroy_metafits_info( struct metafits_info *mi );

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -348,8 +348,6 @@ void get_delays(
     int nconfigs = 138;
     int config_idx;
     double *jones[nconfigs]; // (see hash_dipole_configs() for explanation of this array)
-    for (n = 0; n < nconfigs; n++)
-        jones[n] = NULL; // i.e. no Jones matrices have been calculated for any configurations so far
 
     double Fnorm;
     // Read in the Jones matrices for this (coarse) channel, if requested
@@ -404,6 +402,10 @@ void get_delays(
 
     for ( int p = 0; p < npointing; p++ )
     {
+
+        // Reset the Jones matrices (for the FEE beam)
+        for (n = 0; n < nconfigs; n++)
+            jones[n] = NULL; // i.e. no Jones matrices have been calculated for any configurations so far
 
         dec_degs = parse_dec( pointing_array[p][1] );
         ra_hours = parse_ra( pointing_array[p][0] );
@@ -593,7 +595,14 @@ void get_delays(
             delay_vals[p].intmjd   = intmjd;
 
         }
-    }
+
+        // Free Jones matrices from hyperbeam -- in prep for reclaculating the next pointing
+        for (n = 0; n < nconfigs; n++)
+        {
+            if (jones[n] != NULL)
+                free( jones[n] );
+        }
+    } // end loop through pointings (p)
 
     // Free up dynamically allocated memory
 
@@ -606,12 +615,6 @@ void get_delays(
     free(Jf);
     free(M);
 
-    // Free Jones matrices from hyperbeam
-    for (n = 0; n < nconfigs; n++)
-    {
-        if (jones[n] != NULL)
-            free( jones[n] );
-    }
 }
 
 int calcEjones_analytic(ComplexDouble response[MAX_POLS], // pointer to 4-element (2x2) voltage gain Jones matrix

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -468,10 +468,16 @@ void get_delays(
                     // The point of this is to save recalculating the jones matrix, which is
                     // computationally expensive.
                     config_idx = hash_dipole_config( mi->amps[row] );
-                    if (jones[config_idx] == NULL)
+                    if (jones[config_idx] == NULL && ch == 0)
                     {
-                        // The Jones matrix for this configuration has not yet been calculated, so do it now
-                        jones[config_idx] = calc_jones( beam, az, DPIBY2-el, freq_ch,
+                        // The Jones matrix for this configuration has not yet been calculated, so do it now.
+                        // The FEE beam only needs to be calculated once per coarse channel, because it will
+                        // not produce unique answers for different fine channels within a coarse channel anyway
+                        // (it only calculates the jones matrix for the nearest coarse channel centre)
+                        // Strictly speaking, the condition (ch == 0) above is redundant, as the dipole configuration
+                        // array takes care of that implicitly, but I'll leave it here so that the above argument
+                        // is "explicit" in the code.
+                        jones[config_idx] = calc_jones( beam, az, DPIBY2-el, frequency + mi->chan_width/2,
                                 (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm );
                     }
 

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -45,6 +45,100 @@ int npol;
 int nstation;
 //=====================//
 
+int hash_dipole_config( double *amps )
+/* In order to avoid recalculating the FEE beam for repeated dipole
+ * configurations, we have to keep track of which configurations have already
+ * been calculated. We do this through a boolean array, and this function
+ * converts dipole configurations into indices of this array. In other words,
+ * this function _assigns meaning_ to the array.
+ *
+ * Since dead dipoles are relatively rare, we only consider configurations
+ * in which up to two dipoles are dead. Any more than that and the we can
+ * recalculate the Jones matrix with minimal entropy. In this case, this
+ * function returns -1. The other remaining cases are:
+ *
+ *   0 dead dipoles = 1   configuration
+ *   1 dead dipole  = 16  configurations
+ *   2 dead dipoles = 120 configurations
+ *
+ * for a grand total of 137 indices. They are ordered as follows:
+ *
+ *  idx  configuration (0=dead, 1=live)
+ *   0   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   1   [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   2   [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   3   [1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   ...
+ *   16  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+ *   17  [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   18  [0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   19  [0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   ...
+ *   31  [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+ *   32  [1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   32  [1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+ *   ...
+ *   136 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+ *
+ *   This function defines "dead" as amps=0.0, "live" otherwise.
+ */
+{
+    // The return value = the "hashed" array index
+    int idx;
+    int d1 = 0, d2 = 0; // The "locations" of the (up to) two dead dipoles
+
+    // Count the number of dead dipoles
+    int ndead = 0;
+    int ndipoles = 16;
+    int i;
+    for (i = 0; i < ndipoles; i++)
+        ndead += (amps[i] == 0.0);
+
+    // Convert configuration into an array index (the "hash" function)
+    switch (ndead)
+    {
+        case 0:
+            idx = 0;
+            break;
+        case 1:
+            for (i = 0; i < ndipoles; i++)
+            {
+                if (amps[i] == 0.0)
+                {
+                    d1 = i;
+                    break;
+                }
+            }
+            idx = d1 + 1; // The "1-dead-dipole" configs start at idx 1
+            break;
+        case 2:
+            // Find the locations of the two dead dipoles
+            d1 = -1;
+            for (i = 0; i < ndipoles; i++)
+            {
+                if (amps[i] == 0.0)
+                {
+                    if (d1 == -1)
+                        d1 = i;
+                    else
+                    {
+                        d2 = i;
+                        break;
+                    }
+                }
+            }
+            // The hash function for two dead dipoles
+            // (The "2-dead-dipole" configs start at idx 17
+            idx = 16*d1 - ((d1 + 2)*(d1 + 1))/2 + d2 + 17;
+            break;
+        default: // any configuration with >2 dead dipoles
+            idx = -1;
+            break;
+    }
+
+    return idx;
+}
+
 double parse_dec( char* dec_ddmmss ) {
 /* Parse a string containing a declination in dd:mm:ss format into
  * a double in units of degrees
@@ -245,6 +339,12 @@ void get_delays(
     double X,Y,Z,u,v,w;
     double geometry, delay_time, delay_samples, cycles_per_sample;
 
+    int nconfigs = 137;
+    int config_idx;
+    double *jones[nconfigs]; // (see hash_dipole_configs() for explanation of this array)
+    for (n = 0; n < nconfigs; n++)
+        jones[n] = NULL; // i.e. no Jones matrices have been calculated for any configurations so far
+
     double Fnorm;
     // Read in the Jones matrices for this (coarse) channel, if requested
     ComplexDouble invJref[4];
@@ -347,7 +447,7 @@ void get_delays(
             }
             if (beam_model == BEAM_ANALYTIC) {
                 // Analytic beam:
-                calcEjones_analytic(E,                                 // pointer to 4-element (2x2) voltage gain Jones matrix
+                calcEjones_analytic(E,                        // pointer to 4-element (2x2) voltage gain Jones matrix
                         freq_ch,                              // observing freq of fine channel (Hz)
                         (MWA_LAT*DD2R),                       // observing latitude (radians)
                         mi->tile_pointing_az*DD2R,            // azimuth & zenith angle of tile pointing
@@ -364,8 +464,16 @@ void get_delays(
 
                 if (beam_model == BEAM_FEE2016) {
                     // FEE2016 beam:
-                    double *jones = calc_jones( beam, az, DPIBY2-el, freq_ch,
-                            (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm );
+                    // Check to see whether or not this configuration has already been calculated.
+                    // The point of this is to save recalculating the jones matrix, which is
+                    // computationally expensive.
+                    config_idx = hash_dipole_config( mi->amps[row] );
+                    if (jones[config_idx] == NULL)
+                    {
+                        // The Jones matrix for this configuration has not yet been calculated, so do it now
+                        jones[config_idx] = calc_jones( beam, az, DPIBY2-el, freq_ch,
+                                (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm );
+                    }
 
                     // "Convert" the real jones[8] output array into out complex E[4] matrix
                     for (n = 0; n<NPOL*NPOL; n++){
@@ -381,11 +489,8 @@ void get_delays(
                         //   3 --> 2
                         // which is achieved by the following translation (n --> m):
                         int m = n - n%2 + (n+1)%2;
-                        E[m] = CMaked(jones[n*2], jones[n*2+1]);
+                        E[m] = CMaked(jones[config_idx][n*2], jones[config_idx][n*2+1]);
                     }
-
-                    // Memory clean up required by Hyperbeam
-                    free(jones);
                 }
                 //fprintf(stderr, "APPLYING HORIZONTAL FLIP\n");
                 mult2x2d(M[ant], invJref, G); // M x J^-1 = G (Forms the "coarse channel" DI gain)
@@ -488,6 +593,13 @@ void get_delays(
     }
     free(Jf);
     free(M);
+
+    // Free Jones matrices from hyperbeam
+    for (n = 0; n < nconfigs; n++)
+    {
+        if (jones[n] != NULL)
+            free( jones[n] );
+    }
 }
 
 int calcEjones_analytic(ComplexDouble response[MAX_POLS], // pointer to 4-element (2x2) voltage gain Jones matrix

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -57,11 +57,12 @@ int hash_dipole_config( double *amps )
  * recalculate the Jones matrix with minimal entropy. In this case, this
  * function returns -1. The other remaining cases are:
  *
- *   0 dead dipoles = 1   configuration
- *   1 dead dipole  = 16  configurations
- *   2 dead dipoles = 120 configurations
+ *   0  dead dipoles = 1   configuration
+ *   1  dead dipole  = 16  configurations
+ *   2  dead dipoles = 120 configurations
+ *   16 dead dipoles = 1   configuration
  *
- * for a grand total of 137 indices. They are ordered as follows:
+ * for a grand total of 138 indices. They are ordered as follows:
  *
  *  idx  configuration (0=dead, 1=live)
  *   0   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
@@ -78,7 +79,9 @@ int hash_dipole_config( double *amps )
  *   32  [1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
  *   32  [1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
  *   ...
+ *   136 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0]
  *   136 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+ *   137 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
  *
  *   This function defines "dead" as amps=0.0, "live" otherwise.
  */
@@ -130,6 +133,9 @@ int hash_dipole_config( double *amps )
             // The hash function for two dead dipoles
             // (The "2-dead-dipole" configs start at idx 17
             idx = 16*d1 - ((d1 + 2)*(d1 + 1))/2 + d2 + 17;
+            break;
+        case 16:
+            idx = 137;
             break;
         default: // any configuration with >2 dead dipoles
             idx = -1;
@@ -339,7 +345,7 @@ void get_delays(
     double X,Y,Z,u,v,w;
     double geometry, delay_time, delay_samples, cycles_per_sample;
 
-    int nconfigs = 137;
+    int nconfigs = 138;
     int config_idx;
     double *jones[nconfigs]; // (see hash_dipole_configs() for explanation of this array)
     for (n = 0; n < nconfigs; n++)
@@ -468,7 +474,7 @@ void get_delays(
                     // The point of this is to save recalculating the jones matrix, which is
                     // computationally expensive.
                     config_idx = hash_dipole_config( mi->amps[row] );
-                    if (jones[config_idx] == NULL && ch == 0)
+                    if ((config_idx == -1 || jones[config_idx] == NULL) && ch == 0)
                     {
                         // The Jones matrix for this configuration has not yet been calculated, so do it now.
                         // The FEE beam only needs to be calculated once per coarse channel, because it will

--- a/tests/test_make_beam.c
+++ b/tests/test_make_beam.c
@@ -54,7 +54,7 @@ int main()
 void test_hash_dipole_config()
 {
     int npassed = 0;
-    int ntests = 4;
+    int ntests = 5;
     double amps1[] = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
     double amps2[] = { 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
@@ -63,16 +63,20 @@ void test_hash_dipole_config()
                        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
     double amps4[] = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                        1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0 };
+    double amps5[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
     double *amps[ntests];
     amps[0] = amps1;
     amps[1] = amps2;
     amps[2] = amps3;
     amps[3] = amps4;
+    amps[4] = amps5;
     int idx[ntests], ans[ntests];
     ans[0] = 0;
     ans[1] = 4;
     ans[2] = 23;
     ans[3] = 131;
+    ans[4] = 137;
 
     // Test #1 -- all dipoles active
     int t;
@@ -85,10 +89,10 @@ void test_hash_dipole_config()
     if (npassed != ntests)
     {
         printf( "test_hash_dipole_config failed:\n" );
-        printf( "\tresults: %3d, %3d, %3d, %3d\n",
-                idx[0], idx[1], idx[2], idx[3] );
-        printf( "\tanswers: %3d, %3d, %3d, %3d\n",
-                ans[0], ans[1], ans[2], ans[3] );
+        printf( "\tresults: %3d, %3d, %3d, %3d, %3d\n",
+                idx[0], idx[1], idx[2], idx[3], idx[4] );
+        printf( "\tanswers: %3d, %3d, %3d, %3d, %3d\n",
+                ans[0], ans[1], ans[2], ans[3], ans[4] );
         status = EXIT_FAILURE;
     }
     printf( "test_hash_dipole_config passed %d/%d tests\n", npassed, ntests );

--- a/tests/test_make_beam.c
+++ b/tests/test_make_beam.c
@@ -38,12 +38,60 @@ void print_2x2double_compare( double *M1, double *M2 );
 
 void test_calcEjones_analytic();
 void test_parallactic_angle_correction();
+void test_hash_dipole_config();
+
+int status;
 
 int main()
 {
+    status = EXIT_SUCCESS;
     test_calcEjones_analytic();
     test_parallactic_angle_correction();
-    return EXIT_SUCCESS;
+    test_hash_dipole_config();
+    return status;
+}
+
+void test_hash_dipole_config()
+{
+    int npassed = 0;
+    int ntests = 4;
+    double amps1[] = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
+    double amps2[] = { 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
+    double amps3[] = { 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0,
+                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
+    double amps4[] = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                       1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0 };
+    double *amps[ntests];
+    amps[0] = amps1;
+    amps[1] = amps2;
+    amps[2] = amps3;
+    amps[3] = amps4;
+    int idx[ntests], ans[ntests];
+    ans[0] = 0;
+    ans[1] = 4;
+    ans[2] = 23;
+    ans[3] = 131;
+
+    // Test #1 -- all dipoles active
+    int t;
+    for (t = 0; t < ntests; t++)
+    {
+        idx[t] = hash_dipole_config( amps[t] );
+        npassed += (idx[t] == ans[t]);
+    }
+
+    if (npassed != ntests)
+    {
+        printf( "test_hash_dipole_config failed:\n" );
+        printf( "\tresults: %3d, %3d, %3d, %3d\n",
+                idx[0], idx[1], idx[2], idx[3] );
+        printf( "\tanswers: %3d, %3d, %3d, %3d\n",
+                ans[0], ans[1], ans[2], ans[3] );
+        status = EXIT_FAILURE;
+    }
+    printf( "test_hash_dipole_config passed %d/%d tests\n", npassed, ntests );
 }
 
 void test_calcEjones_analytic()
@@ -77,6 +125,7 @@ void test_calcEjones_analytic()
     {
         printf( "test_calcEjones_analytic (test %d) failed:\n", ntests );
         print_2x2cmplx_compare( response, answer );
+        status = EXIT_FAILURE;
     }
 
     printf( "test_calcEJones_analytic() passed %d/%d tests\n", npassed, ntests );
@@ -112,6 +161,7 @@ void test_parallactic_angle_correction()
     {
         printf( "test_parallactic_angle_correction (test %d) failed:\n", ntests );
         print_2x2double_compare( output, answer );
+        status = EXIT_FAILURE;
     }
 
     // Test #2
@@ -136,6 +186,7 @@ void test_parallactic_angle_correction()
     {
         printf( "test_parallactic_angle_correction (test %d) failed:\n", ntests );
         print_2x2double_compare( output, answer );
+        status = EXIT_FAILURE;
     }
 
     printf( "test_parallactic_angle_correction() passed %d/%d tests\n", npassed, ntests );


### PR DESCRIPTION
This speeds up the delays calculation step of make_beam significantly. It avoids duplicate calls to the calc_jones() function by keeping track of which dipole configurations (by which I mean, combinations of live vs dead dipoles) have already been calculated.