### PR TITLE
Updated how subprocess_pdv works

### DIFF
--- a/vcstools/prof_utils.py
+++ b/vcstools/prof_utils.py
@@ -33,7 +33,8 @@ class NoFitError(Exception):
 #---------------------------------------------------------------
 def subprocess_pdv(archive, outfile="archive.txt", pdvops="-FTt"):
     """
-    Runs the pdv commnand from PSRCHIVE as a python subprocess
+    Runs the pdv commnand from PSRCHIVE as a python subprocess.
+    NOTE: Requires singularity loaded in environment (module load singularity)
 
     Parameters
     ----------
@@ -50,7 +51,8 @@ def subprocess_pdv(archive, outfile="archive.txt", pdvops="-FTt"):
         commands.append("pdv")
         commands.append(pdvops)
         commands.append(archive)
-        subprocess.run(commands, stdout=f)
+        a = subprocess.check_output(commands)
+        f.write(a.decode("utf-8"))
 
 #---------------------------------------------------------------
 def get_from_bestprof(file_loc):


### PR DESCRIPTION
I encountered an issue using rm_synthesis. Turns out the error was because my environment didn't have singularity loaded. I didn't like that there was no error message from subprocess so now it'll spit out an error if this occurs.