### PR TITLE
Combined deleted check

### DIFF
--- a/scripts/process_vcs.py
+++ b/scripts/process_vcs.py
@@ -64,8 +64,9 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
     logger.info("Downloading files from archive")
     voltdownload = "voltdownload.py"
     obsinfo = meta.getmeta(service='obs', params={'obs_id':str(obsid)})
+    comb_del_check = meta.combined_deleted_check(obsid, begin=start_time, end=stop_time)
     data_format = obsinfo['dataquality']
-    if data_format == 1:
+    if data_format == 1 or (comb_del_check and data_format == 6):
         target_dir = link = '/raw'
         if ics:
             logger.error("Data have not been recombined in the "

--- a/scripts/process_vcs.py
+++ b/scripts/process_vcs.py
@@ -67,6 +67,8 @@ def vcs_download(obsid, start_time, stop_time, increment, data_dir,
     comb_del_check = meta.combined_deleted_check(obsid, begin=start_time, end=stop_time)
     data_format = obsinfo['dataquality']
     if data_format == 1 or (comb_del_check and data_format == 6):
+        # either only the raw data is available (data_format == 1) 
+        # or there was combined files but they were deleted (comb_del_check and data_format == 6)
         target_dir = link = '/raw'
         if ics:
             logger.error("Data have not been recombined in the "

--- a/vcstools/metadb_utils.py
+++ b/vcstools/metadb_utils.py
@@ -521,5 +521,6 @@ def combined_deleted_check(obsid, begin=None, end=None):
             if remote_archived and not deleted:
                 # A combined file exists
                 comb_del_check = False
+                break
 
     return comb_del_check

--- a/vcstools/metadb_utils.py
+++ b/vcstools/metadb_utils.py
@@ -483,3 +483,43 @@ def get_best_cal_obs(obsid):
     cal_info = sorted(cal_info, key=itemgetter(1))
 
     return cal_info
+
+
+def combined_deleted_check(obsid, begin=None, end=None):
+    """
+    Check if the combined files are deleted (or do not exist)
+
+    Parameters
+    ----------
+    obsid: int
+        The MWA observation ID (gps time)
+    begin: int
+        The begin GPS time to check (optional)
+    end:   int
+        The end GPS time to check (optional)
+
+    Returns
+    -------
+    comb_del_check: bool
+        True if all combined files are deleted or if they do not exist
+    """
+    # Work out the data_files metadata call parameters
+    params = {'obs_id':obsid, 'nocache':1}
+    if begin is not None:
+        params['mintime'] = begin
+    if end is not None:
+        params['maxtime'] = end
+
+    files_meta = getmeta(service='data_files', params=params)
+
+    # Loop over files to search for a non deleted file
+    comb_del_check = True
+    for file in files_meta.keys():
+        if 'combined' in file:
+            deleted =         files_meta[file]['deleted']
+            remote_archived = files_meta[file]["remote_archived"]
+            if remote_archived and not deleted:
+                # A combined file exists
+                comb_del_check = False
+
+    return comb_del_check


### PR DESCRIPTION
There was an error where the metadata will mark the obs as having the combined data type, but since they have been deleted, the download will fail. I added a check to see if the combined files were deleted. If so, download the raw instead.