### PR TITLE
Find freq obs

### DIFF
--- a/scripts/find_pulsar_in_obs.py
+++ b/scripts/find_pulsar_in_obs.py
@@ -332,7 +332,6 @@ if __name__ == "__main__":
     if not degrees_check:
         names_ra_dec = format_ra_dec(names_ra_dec, ra_col=1, dec_col=2)
     names_ra_dec = np.array(names_ra_dec)
-    exit()
 
     #Check if the user wants to use --obs for source
     if (len(names_ra_dec) ==1) and (not args.obs_for_source):

--- a/scripts/find_pulsar_in_obs.py
+++ b/scripts/find_pulsar_in_obs.py
@@ -261,6 +261,8 @@ if __name__ == "__main__":
                         help='The minimum observation duration to include in output files. Default 0')
     parser.add_argument('--freq_chan', type=int,
                         help='Only use observations that include this frequency channel.')
+    parser.add_argument('--contig', action='store_true',
+                        help='Only use observations that have contiguous frequency channels.')
     obargs.add_argument('--all_volt', action='store_true',
                         help='Includes observation IDs even if there are no raw voltages in the archive. Some incoherent observation ID files may be archived even though there are raw voltage files. The default is to only include files with raw voltage files.')
     obargs.add_argument('--cal_check', action='store_true',
@@ -352,6 +354,11 @@ if __name__ == "__main__":
         # Update params to only use obs that contain this frequency channel
         params.update({'anychan':args.freq_chan})
         logger.debug("params: {}".format(params))
+    if args.contig:
+        # Update params to only use obs that have contiguous channels
+        params.update({'contigfreq':1})
+        logger.debug("params: {}".format(params))
+
     if args.obsid:
         obsid_list = args.obsid
     elif args.FITS_dir:

--- a/scripts/mwa_metadb_utils.py
+++ b/scripts/mwa_metadb_utils.py
@@ -25,8 +25,32 @@ if __name__ == '__main__':
         centre_freq = ( min(channels) + max(channels) ) / 2. * 1.28
         array_phase = get_obs_array_phase(args.obsid)
         start, stop = obs_max_min(args.obsid)
-        available_files, all_files = files_available(args.obsid)
         fov = field_of_view(args.obsid, beam_meta_data=beam_common_data)
+
+        # Check available files
+        available_files, all_files = files_available(args.obsid)
+        # Split into raw and combined files to give a clearer idea of files available
+        available_comb = []
+        available_raw  = []
+        available_ics  = []
+        all_comb = []
+        all_raw  = []
+        all_ics  = []
+        for file_name in all_files:
+            if 'combined' in file_name:
+                all_comb.append(file_name)
+                if file_name in available_files:
+                    available_comb.append(file_name)
+            elif 'ics' in file_name:
+                all_ics.append(file_name)
+                if file_name in available_files:
+                    available_ics.append(file_name)
+            else:
+                all_raw.append(file_name)
+                if file_name in available_files:
+                    available_raw.append(file_name)
+        print(available_raw)
+        #print(available_comb)
 
         print("-------------------------    Obs Info    --------------------------")
         print("Obs Name:           {}".format(data_dict["obsname"]))
@@ -41,8 +65,12 @@ if __name__ == '__main__':
             print("Start time:         {}".format(start))
             print("Stop time:          {}".format(stop))
             print("Duration (s):       {}".format(stop-start))
-            print("Files available:    {:4.1f}%  ({}/{})".format(len(available_files)/len(all_files)*100,
-                                                            len(available_files), len(all_files)))
+            print("Raw  files avail:   {:5.1f}%  ({}/{})".format(len(available_raw)/len(all_raw)*100,
+                                                                 len(available_raw), len(all_raw)))
+            print("ICS  files avail:   {:5.1f}%  ({}/{})".format(len(available_ics)/len(all_ics)*100,
+                                                                 len(available_ics), len(all_ics)))
+            print("Comb files avail:   {:5.1f}%  ({}/{})".format(len(available_comb)/len(all_comb)*100,
+                                                                 len(available_comb), len(all_comb)))
         print("RA Pointing (deg):  {}".format(data_dict["metadata"]["ra_pointing"]))
         print("DEC Pointing (deg): {}".format(data_dict["metadata"]["dec_pointing"]))
         print("Channels:           {}".format(data_dict["rfstreams"]["0"]["frequencies"]))

--- a/vcstools/metadb_utils.py
+++ b/vcstools/metadb_utils.py
@@ -85,8 +85,8 @@ def singles_source_search(ra, dec=None, box_size=45., params=None):
             m_o_p = True
 
     if m_o_p:
-        obsid_list = find_obsids_meta_pages(params=params.update({'minra':0.,      'maxra':360.,
-                                                                  'mindec':dec_bot,'maxdec':dec_top}))
+        params.update({'minra':0.,      'maxra':360.,
+                       'mindec':dec_bot,'maxdec':dec_top})
     else:
         ra_low = ra - 30. - box_size #30 is the how far an obs would drift in 2 hours(used as a max)
         ra_high = ra + box_size
@@ -94,8 +94,10 @@ def singles_source_search(ra, dec=None, box_size=45., params=None):
             ra_new = 360 + ra_low
         if ra_high > 360:
             ra_new = ra_high - 360
-        obsid_list = find_obsids_meta_pages(params=params.update({'minra':ra_low,  'maxra':ra_high,
-                                                                    'mindec':dec_bot,'maxdec':dec_top}))
+        params.update({'minra':ra_low,  'maxra':ra_high,
+                       'mindec':dec_bot,'maxdec':dec_top})
+    logger.debug("params: {}".format(params))
+    obsid_list = find_obsids_meta_pages(params=params)
     return obsid_list
 
 def find_obsids_meta_pages(params=None):

--- a/vcstools/metadb_utils.py
+++ b/vcstools/metadb_utils.py
@@ -38,7 +38,7 @@ def ensure_metafits(data_dir, obs_id, metafits_file):
         copy2("{0}".format(metafits_file), "{0}".format(data_dir))
 
 
-def singles_source_search(ra, dec=None, box_size=45.):
+def singles_source_search(ra, dec=None, box_size=45., params=None):
     """
     Used to find all obsids within a box around the source to make searching through obs_ids more efficient.
 
@@ -51,12 +51,21 @@ def singles_source_search(ra, dec=None, box_size=45.):
         Declination of the source in degrees. By default will use the enitre declination range to account for grating lobes
     box_size: float
         Radius of the search box. Default: 45
+    params: dict
+        The dictionary of constraints used to search for suitable observations as explained here:
+        https://wiki.mwatelescope.org/display/MP/Web+Services#WebServices-Findobservations
+        Default: {'mode':'VOLTAGE_START'}
 
     Returns:
     --------
     obsid_metadata: list
-        List of of the metadata for each obsid. The metadata is in the same format as getmeta's output
+        List of the metadata for each obsid. The metadata is in the same format as getmeta's output
     """
+    if params is None:
+        # Load default params
+        params={'mode':'VOLTAGE_START'}
+    logger.debug("params: {}".format(params))
+
     ra = float(ra)
     m_o_p = False # moved over (north or south) pole
 
@@ -76,41 +85,34 @@ def singles_source_search(ra, dec=None, box_size=45.):
             m_o_p = True
 
     if m_o_p:
-        obsid_list = find_obsids_meta_pages(params={'mode':'VOLTAGE_START',
-                                                    'minra':0., 'maxra':360.,
-                                                    'mindec':dec_bot,'maxdec':dec_top})
+        obsid_list = find_obsids_meta_pages(params=params.update({'minra':0.,      'maxra':360.,
+                                                                  'mindec':dec_bot,'maxdec':dec_top}))
     else:
         ra_low = ra - 30. - box_size #30 is the how far an obs would drift in 2 hours(used as a max)
         ra_high = ra + box_size
         if ra_low < 0.:
             ra_new = 360 + ra_low
-            obsid_list = find_obsids_meta_pages(params={'mode':'VOLTAGE_START',
-                                                        'minra':ra_new, 'maxra':360.,
-                                                        'mindec':dec_bot,'maxdec':dec_top})
-            temp_obsid_list = find_obsids_meta_pages(params={'mode':'VOLTAGE_START',
-                                                             'minra':0.,'maxra':ra_high,
-                                                             'mindec':dec_bot,'maxdec':dec_top})
-            for row in temp_obsid_list:
-                obsid_list.append(row)
-        elif ra_high > 360:
+        if ra_high > 360:
             ra_new = ra_high - 360
-            obsid_list = find_obsids_meta_pages(params={'mode':'VOLTAGE_START',
-                                                        'minra':ra_low, 'maxra':360.,
-                                                        'mindec':dec_bot,'maxdec':dec_top})
-            temp_obsid_list = find_obsids_meta_pages(params={'mode':'VOLTAGE_START',
-                                                             'minra':0., 'maxra':ra_new,
-                                                             'mindec':dec_bot,'maxdec':dec_top})
-            for row in temp_obsid_list:
-                obsid_list.append(row)
-        else:
-            obsid_list = find_obsids_meta_pages(params={'mode':'VOLTAGE_START',
-                                                        'minra':ra_low, 'maxra':ra_high,
-                                                        'mindec':dec_bot,'maxdec':dec_top})
+        obsid_list = find_obsids_meta_pages(params=params.update({'minra':ra_low,  'maxra':ra_high,
+                                                                    'mindec':dec_bot,'maxdec':dec_top}))
     return obsid_list
 
 def find_obsids_meta_pages(params=None):
     """
     Loops over pages for each page for MWA metadata calls
+
+    Parameters:
+    --------
+    params: dict
+        The dictionary of constraints used to search for suitable observations as explained here:
+        https://wiki.mwatelescope.org/display/MP/Web+Services#WebServices-Findobservations
+        Default: {'mode':'VOLTAGE_START'}
+
+    Returns:
+    --------
+    obsid_list: list
+        List of observation IDs.
     """
     if params is None:
         params = {'mode':'VOLTAGE_START'}


### PR DESCRIPTION
Upgrades:
- Added the option (--contig) to find_pulsar_in_obs.py to only use observations with contiguous frequency channels
- Added the option (--freq_chan) to find_pulsar_in_obs.py to only use observations that contain the input frequency channels
-  Split the "files available" output of mwa_metadb_utils.py to make it clearer what is available (raw, ICS or combined)

