### PR TITLE
Minor fix to observation data files query

### DIFF
--- a/vcstools/beam_calc.py
+++ b/vcstools/beam_calc.py
@@ -562,11 +562,9 @@ def find_sources_in_obs(obsid_list, names_ra_dec,
 
     # Loop over observations to check if there are VCS files
     for i, obsid in enumerate(obsid_list):
-        # Perform the file meta data call over 10 only 10 seconds as that is suffient test
+        # Perform the file meta data call to ensure data is available, just ask for the first 10
         try:
-            files_meta_data = getmeta(service='data_files', params={'obs_id':obsid, 'nocache':1,
-                                                                    'mintime':int(obsid) + 10,
-                                                                    'maxtime':int(obsid) + 20})
+            files_meta_data = getmeta(service='data_files', params={'obs_id':obsid, 'nocache':1, 'maxfiles':10})
         except urllib.error.HTTPError as err:
             files_meta_data = None
         if files_meta_data is None:


### PR DESCRIPTION
Addresses #228. The function now executes a query that requests the first 10 data files (rather than specifying a time range or retrieving _all_ file information). 

I've confirmed this solves the issue Ting Yu was having where some observations without data files were returning errors rather than the metadata. There is still a warning that there are no data files when that is the case, but it no longer causes an error and/or empty return JSON payloads. 