### PR TITLE
Remove manual download and access to psrcat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ reqs = ['astropy>=3.2.1',
 
 # Download the ANTF_pulsar_database_file file if it doesn't exist
 datadir = os.path.join(os.path.dirname(__file__), 'vcstools', 'data')
-download_ANTF_pulsar_database_file(datadir)
 
 
 #vcstools_version = get_git_version()

--- a/setup.py
+++ b/setup.py
@@ -27,47 +27,6 @@ def get_git_version():
     git_version = check_output('git describe --tags --long --dirty --always'.split()).decode('utf-8').strip()
     return format_version(version=git_version)
 
-def download_ANTF_pulsar_database_file(datadir, version=None):
-    """Download and untar the ATNF psrcat database file and put it in a directory
-
-    Parameters
-    ----------
-    datadir : `str`
-        The directory where you wish to put the database file.
-    version : `str`, optional
-        The version of the database you would like to download e.g. v1.65. Default: None (download latest version)
-    """
-    # Hard code the path of the ATNF psrcat database file
-    ATNF_LOC = os.path.join(datadir, 'psrcat.db')
-    # Check if the file exists, if not download the latest zersion
-    if not os.path.exists(ATNF_LOC):
-        # Importing download functions here to avoid unnessiary imports when the file is available
-        import urllib.request
-        import gzip
-        import shutil
-        import tarfile
-        print("The ANTF psrcat database file does not exist. Downloading it from www.atnf.csiro.au")
-        if version is None:
-            # Grab latest file
-            tar_name = 'psrcat_pkg.tar.gz'
-        else:
-            tar_name = 'psrcat_pkg.{}.tar.gz'.format(version)
-        # Download the file. Comment at line-end to disable linter secuirty check.
-        psrcat_zip_dir = urllib.request.urlretrieve(f"https://www.atnf.csiro.au/research/pulsar/psrcat/downloads/{tar_name}")[0]  # nosec
-
-        # Unzip it
-        with gzip.open(psrcat_zip_dir,  'rb') as f_in:
-            with open(tar_name, 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-        # Untar the file we require
-        psrcat_tar = tarfile.open(psrcat_zip_dir)
-        # Do some python magic to no download the file within it's subdirectory from
-        # https://stackoverflow.com/questions/8405843/python-extract-using-tarfile-but-ignoring-directories
-        member = psrcat_tar.getmember('psrcat_tar/psrcat.db')
-        member.name = os.path.basename(member.name)
-        psrcat_tar.extract(member, path=datadir)
-        print("Download complete")
-        os.remove(tar_name)
 
 reqs = ['astropy>=3.2.1',
         'argparse>=1.4.0',

--- a/tests/test_prof_utils.py
+++ b/tests/test_prof_utils.py
@@ -13,17 +13,7 @@ from vcstools.general_utils import setup_logger
 
 import logging
 logger = logging.getLogger(__name__)
-#logger = setup_logger(logger, log_level="DEBUG")
 
-"""
-#Global obsid information to speed things up
-md_dict={}
-obsid_list = [1222697776, 1226062160, 1225713560, 1117643248]
-for obs in obsid_list:
-    md_dict[str(obs)] = get_common_obs_metadata(obs, return_all=True)
-
-query = psrqpy.QueryATNF(loadfromdb=data_load.ATNF_LOC).pandas
-"""
 # The three tests of the flux calculation methods. They should be close to imaging results:
 test_pulsars = []
 # J1820-0427 298.5 sigma. A bright pulsar with two components and a scattering tail that is about 50% of the profile

--- a/tests/test_radiometer_equation.py
+++ b/tests/test_radiometer_equation.py
@@ -17,7 +17,6 @@ from vcstools.radiometer_equation import find_t_sys_gain, find_pulsar_w50,\
 
 import logging
 logger = logging.getLogger(__name__)
-#logger = setup_logger(logger, log_level="DEBUG")
 
 
 #Global obsid information to speed things up
@@ -26,7 +25,7 @@ obsid_list = [1222697776, 1226062160, 1225713560, 1117643248]
 for obs in obsid_list:
     md_dict[str(obs)] = get_common_obs_metadata(obs, return_all=True)
 
-query = psrqpy.QueryATNF(loadfromdb=data_load.ATNF_LOC).pandas
+query = psrqpy.QueryATNF().pandas
 
 # The five pulsars from 1276619416 that were also detected in imaging.
 pulsars_to_test = []

--- a/vcstools/beam_calc.py
+++ b/vcstools/beam_calc.py
@@ -462,7 +462,7 @@ def source_beam_coverage_and_times(obsid, pulsar,
     """
     # Perform required metadata calls
     if query is None:
-        query = psrqpy.QueryATNF(psrs=pulsar, loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(psrs=pulsar).pandas
     if p_ra is None or p_dec is None:
         # Get some basic pulsar and obs info info
         query_id = list(query['PSRJ']).index(pulsar)

--- a/vcstools/catalogue_utils.py
+++ b/vcstools/catalogue_utils.py
@@ -41,7 +41,7 @@ def get_psrcat_ra_dec(pulsar_list=None, max_dm=5000., include_dm=False, query=No
             The Declination in the format "DD:MM:SS.SS".
     """
     if query is None:
-        query = psrqpy.QueryATNF(params = ['PSRJ', 'RAJ', 'DECJ', 'RAJD', 'DECJD', 'DM'], psrs=pulsar_list, loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(params = ['PSRJ', 'RAJ', 'DECJ', 'RAJD', 'DECJD', 'DM'], psrs=pulsar_list).pandas
     pulsar_ra_dec = []
     for i, _ in enumerate(query["PSRJ"]):
         # Only record if under the max_dm
@@ -92,7 +92,7 @@ def get_psrcat_dm_period(pulsar_list=None, query=None):
             The period of the puslsar in seconds.
     """
     if query is None:
-        query = psrqpy.QueryATNF(params = ['PSRJ', 'DM', 'P0'], psrs=pulsar_list, loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(params = ['PSRJ', 'DM', 'P0'], psrs=pulsar_list).pandas
 
     pulsar_dm_p = []
     for i, _ in enumerate(query["PSRJ"]):

--- a/vcstools/data_load.py
+++ b/vcstools/data_load.py
@@ -13,5 +13,3 @@ TRCVR_FILE = os.path.join(datadir, 'MWA_Trcvr_tile_56.csv')
 KNOWN_RFRB_CSV = os.path.join(datadir, 'known_repeating_FRBs.csv')
 POI_CSV = os.path.join(datadir, 'points_of_interest.csv')
 
-# Hard code the path of the ATNF psrcat database file
-ATNF_LOC = os.path.join(datadir, 'psrcat.db')

--- a/vcstools/pulsar_spectra.py
+++ b/vcstools/pulsar_spectra.py
@@ -327,7 +327,7 @@ def flux_from_atnf(pulsar, query=None):
         The ucnertainty in spind from ATNF, will be None if not available.
     """
     if query is None:
-        query = psrqpy.QueryATNF(psrs=[pulsar], loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(psrs=[pulsar]).pandas
     query_id = list(query['PSRJ']).index(pulsar)
 
     flux_queries = ["S40", "S50", "S60", "S80", "S100", "S150", "S200",\

--- a/vcstools/radiometer_equation.py
+++ b/vcstools/radiometer_equation.py
@@ -360,7 +360,7 @@ def est_pulsar_flux(pulsar, obsid, plot_flux=False, common_metadata=None, query=
         The estimated flux's uncertainty in Jy.
     """
     if query is None:
-        query = psrqpy.QueryATNF(psrs=[pulsar], loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(psrs=[pulsar]).pandas
     query_id = list(query['PSRJ']).index(pulsar)
     if common_metadata is None:
         logger.debug("Obtaining mean freq from obs metadata")
@@ -401,7 +401,7 @@ def find_pulsar_w50(pulsar, query=None):
     if query is None:
         #returns W_50 and error for a pulsar from the ATNF archive IN SECONDS
         logger.debug("Accessing ATNF database")
-        query = psrqpy.QueryATNF(psrs=[pulsar], loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(psrs=[pulsar]).pandas
     query_id = list(query['PSRJ']).index(pulsar)
 
     W_50     = query["W50"][query_id]
@@ -494,7 +494,7 @@ def find_t_sys_gain(pulsar, obsid,
     # get ra and dec if not supplied
     if query is None:
         logger.debug("Obtaining pulsar RA and Dec from ATNF")
-        query = psrqpy.QueryATNF(psrs=[pulsar], loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(psrs=[pulsar]).pandas
     query_id = list(query['PSRJ']).index(pulsar)
     if not p_ra or not p_dec:
         p_ra = query["RAJ"][query_id]
@@ -601,7 +601,7 @@ def est_pulsar_sn(pulsar, obsid,
     # We will attain uncertainties for s_mean, gain, t_sys and W_50.
     # other uncertainties are considered negligible
     if query is None:
-        query = psrqpy.QueryATNF(psrs=pulsar, loadfromdb=data_load.ATNF_LOC).pandas
+        query = psrqpy.QueryATNF(psrs=pulsar).pandas
     query_id = list(query['PSRJ']).index(pulsar)
     if cat_dict is None:
         cat_dict = collect_catalogue_fluxes()
@@ -735,7 +735,7 @@ def multi_psr_snfe(pulsar_list, obsid, obs_beg, obs_end,
     if obs_beg is None or obs_end is None:
         obs_beg, obs_end = obs_max_min(obsid)
 
-    mega_query = psrqpy.QueryATNF(psrs=pulsar_list, loadfromdb=data_load.ATNF_LOC).pandas
+    mega_query = psrqpy.QueryATNF(psrs=pulsar_list).pandas
     cat_dict = collect_catalogue_fluxes()
     sn_dict = {}
     for i, pulsar in enumerate(progress_bar(mega_query["PSRJ"], "Calculating pulsar SN: ")):


### PR DESCRIPTION
`psrqpy` is able to access the ATNF pulsar catalogue without us having to provide the actual database, so to simplify our install we are removing the previous attempt to speed things up (which didn't really work anyway). 