### PR TITLE
Fix calc_jones call to work with recent versions of hyperbeam

### DIFF
--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -501,7 +501,7 @@ void get_delays(
                         
                         if (errInt != 0)
                         {             
-                            printf("Error encountered when computing beam Jones matrix via hyperbeam (line: %d, code: %d)\n" % (errInt, 495));
+                            printf("Error encountered when computing beam Jones matrix via hyperbeam (line: %d, code: %d)\n", errInt, 496);
                             exit(EXIT_FAILURE);
                         }
                     }

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -347,7 +347,12 @@ void get_delays(
 
     int nconfigs = 138;
     int config_idx;
+    int errInt; // error code tracking for hyperbeam
     double *jones[nconfigs]; // (see hash_dipole_configs() for explanation of this array)
+    // Allocate the memory here since hyperbeam expects a "buffer" as input
+    for (n = 0; n < nconfigs; n++) {
+        jones[n] = malloc(8*sizeof(double));
+    }
 
     double Fnorm;
     // Read in the Jones matrices for this (coarse) channel, if requested
@@ -485,8 +490,20 @@ void get_delays(
                         // Strictly speaking, the condition (ch == 0) above is redundant, as the dipole configuration
                         // array takes care of that implicitly, but I'll leave it here so that the above argument
                         // is "explicit" in the code.
-                        jones[config_idx] = calc_jones( beam, az, PAL__DPIBY2-el, frequency + mi->chan_width/2,
-                                (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm );
+                        
+                        // **NOTE** For newer versions of hyperbeam (i.e., >v0.2 or so) we need to provide additional 
+                        // arguments including the buffer for the Jones matrix data to be stored
+                        errInt = calc_jones( beam, az, PAL__DPIBY2-el, frequency + mi->chan_width/2,
+                                (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm,
+                                NULL, // stand-in for array latitude
+                                0, // use IAU ordering (0 = don't)
+                                (double*)jones[config_idx] );
+                        
+                        if (errInt != 0)
+                        {             
+                            printf("Error encountered when computing beam Jones matrix via hyperbeam (line: %d, code: %d)\n" % (errInt, 495));
+                            exit(EXIT_FAILURE);
+                        }
                     }
 
                     // "Convert" the real jones[8] output array into out complex E[4] matrix


### PR DESCRIPTION
Recent versions of `hyperbeam` require a slightly different function call signature, and also require the user input a "buffer" which is then populated with the Jones matrices (thus we need to manage memory on our side and construct the Jones matrices arrays appropriately).