### PR TITLE
Extra fixes to resolve bug when using later versions of hyperbeam

### DIFF
--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -501,7 +501,7 @@ void get_delays(
                         
                         if (errInt != 0)
                         {             
-                            printf("Error encountered when computing beam Jones matrix via hyperbeam (line: %d, code: %d)\n" % (errInt, 495));
+                            printf("Error encountered when computing beam Jones matrix via hyperbeam (line: %d, code: %d)\n", errInt, 496);
                             exit(EXIT_FAILURE);
                         }
                     }

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -407,11 +407,6 @@ void get_delays(
 
     for ( int p = 0; p < npointing; p++ )
     {
-
-        // Reset the Jones matrices (for the FEE beam)
-        for (n = 0; n < nconfigs; n++)
-            jones[n] = NULL; // i.e. no Jones matrices have been calculated for any configurations so far
-
         dec_degs = parse_dec( pointing_array[p][1] );
         ra_hours = parse_ra( pointing_array[p][0] );
 

--- a/make_beam/get_delays_small.c
+++ b/make_beam/get_delays_small.c
@@ -347,7 +347,12 @@ void get_delays(
 
     int nconfigs = 138;
     int config_idx;
+    int errInt; // error code tracking for hyperbeam
     double *jones[nconfigs]; // (see hash_dipole_configs() for explanation of this array)
+    // Allocate the memory here since hyperbeam expects a "buffer" as input
+    for (n = 0; n < nconfigs; n++) {
+        jones[n] = malloc(8*sizeof(double));
+    }
 
     double Fnorm;
     // Read in the Jones matrices for this (coarse) channel, if requested
@@ -485,8 +490,20 @@ void get_delays(
                         // Strictly speaking, the condition (ch == 0) above is redundant, as the dipole configuration
                         // array takes care of that implicitly, but I'll leave it here so that the above argument
                         // is "explicit" in the code.
-                        jones[config_idx] = calc_jones( beam, az, PAL__DPIBY2-el, frequency + mi->chan_width/2,
-                                (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm );
+                        
+                        // **NOTE** For newer versions of hyperbeam (i.e., >v0.2 or so) we need to provide additional 
+                        // arguments including the buffer for the Jones matrix data to be stored
+                        errInt = calc_jones( beam, az, PAL__DPIBY2-el, frequency + mi->chan_width/2,
+                                (unsigned int*)mi->delays[row], mi->amps[row], zenith_norm,
+                                NULL, // stand-in for array latitude
+                                0, // use IAU ordering (0 = don't)
+                                (double*)jones[config_idx] );
+                        
+                        if (errInt != 0)
+                        {             
+                            printf("Error encountered when computing beam Jones matrix via hyperbeam (line: %d, code: %d)\n" % (errInt, 495));
+                            exit(EXIT_FAILURE);
+                        }
                     }
 
                     // "Convert" the real jones[8] output array into out complex E[4] matrix

--- a/make_beam/make_beam.c
+++ b/make_beam/make_beam.c
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
     fprintf( stderr, "[%f]  Reading in beam model from %s\n", NOW-begintime, HYPERBEAM_HDF5 );
     FEEBeam *beam = NULL;
     if (opts.beam_model == BEAM_FEE2016) {
-        new_fee_beam( HYPERBEAM_HDF5, beam );
+        new_fee_beam( HYPERBEAM_HDF5, &beam );
     }
 
     // Read in info from metafits file

--- a/make_beam/make_beam.c
+++ b/make_beam/make_beam.c
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
     fprintf( stderr, "[%f]  Reading in beam model from %s\n", NOW-begintime, HYPERBEAM_HDF5 );
     FEEBeam *beam = NULL;
     if (opts.beam_model == BEAM_FEE2016) {
-        beam = new_fee_beam( HYPERBEAM_HDF5 );
+        new_fee_beam( HYPERBEAM_HDF5, beam );
     }
 
     // Read in info from metafits file

--- a/tests/beam_model_jones_comparison.c
+++ b/tests/beam_model_jones_comparison.c
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
 
         // Load the FEE2016 beam, if requested
         if (opts.beam_model == BEAM_FEE2016) {
-            new_fee_beam( HYPERBEAM_HDF5, beam );
+            new_fee_beam( HYPERBEAM_HDF5, &beam );
         }
         FILE *f = fopen(comp_fname, "w");
         for (file_no = 0; file_no < nfiles; file_no++)

--- a/tests/beam_model_jones_comparison.c
+++ b/tests/beam_model_jones_comparison.c
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
 
         // Load the FEE2016 beam, if requested
         if (opts.beam_model == BEAM_FEE2016) {
-            beam = new_fee_beam( HYPERBEAM_HDF5 );
+            new_fee_beam( HYPERBEAM_HDF5, beam );
         }
         FILE *f = fopen(comp_fname, "w");
         for (file_no = 0; file_no < nfiles; file_no++)


### PR DESCRIPTION
Simple fixes including some good ol' pointer fun and removing an unnecessary "nullification" of our Jones matrices (since they are now `FEEBeam` object buffers that we want to pass on). 